### PR TITLE
Better way to handle the case that no new feed is returned

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,7 +263,7 @@ var async = module.parent.require('async'),
 						callback(e);
 					}
 				} else {
-						callback(new Error('No new feed is returned'));
+					callback(new Error('No new feed is returned'));
 				}
 			} else {
 				callback(err);

--- a/index.js
+++ b/index.js
@@ -255,11 +255,17 @@ var async = module.parent.require('async'),
 			timeout: 120000
 		}, function (err, response, body) {
 			if (!err && response.statusCode === 200) {
-				try {
-					var p = JSON.parse(body);
-					callback(null, p.query.results.feed);
-				} catch (e) {
-					callback(e);
+				if (p.count > 0) {
+					try {
+						var p = JSON.parse(body);
+						callback(null, p.query.results.feed);
+					} catch (e) {
+						callback(e);
+					}
+				} else {
+						callback({
+							message: 'No new feed is returned'
+						});
 				}
 			} else {
 				callback(err);

--- a/index.js
+++ b/index.js
@@ -263,9 +263,7 @@ var async = module.parent.require('async'),
 						callback(e);
 					}
 				} else {
-						callback({
-							message: 'No new feed is returned'
-						});
+						callback(new Error('No new feed is returned'));
 				}
 			} else {
 				callback(err);


### PR DESCRIPTION
Currently, if no new feed is returned, it causes an error message like "TypeError: Cannot read property 'feed' of null" in the log. Use ```p.count``` to better handle this case.