### PR TITLE
Use internal topics API instead of calling topics lib directly, pass `timestamp` directly into method

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ RssPlugin.init = async function (params) {
  * Called on `action:topic.purge`
  */
 RssPlugin.onTopicPurge = async function (data) {
+	if (!utils.isNumber(data.topic.tid)) {
+		return;
+	}
+
 	const feedUrls = await db.getSetMembers('nodebb-plugin-rss:feeds');
 	const keys = feedUrls.map(url => `nodebb-plugin-rss:feed:${url}:uuid`);
 	await db.sortedSetsRemoveRangeByScore(keys, data.topic.tid, data.topic.tid);

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -3,8 +3,8 @@
 const winston = require.main.require('winston');
 const db = require.main.require('./src/database');
 const meta = require.main.require('./src/meta');
-const topics = require.main.require('./src/topics');
 const user = require.main.require('./src/user');
+const api = require.main.require('./src/api');
 
 const feedAPI = require('./feed');
 
@@ -53,7 +53,7 @@ async function postEntry(feed, entry) {
 
 	const isNew = await isEntryNew(feed, entry);
 	if (!isNew) {
-		winston.info(`[plugin-rss] entry is not new, id: ${entry.id}, title: ${entry.title}, link: ${entry.link && entry.link.href}`);
+		winston.verbose(`[plugin-rss] entry is not new, id: ${entry.id}, title: ${entry.title}, link: ${entry.link && entry.link.href}`);
 		return;
 	}
 
@@ -73,9 +73,9 @@ async function postEntry(feed, entry) {
 		tags = tags.concat(entryTags);
 	}
 
-	winston.info(`[plugin-rss] posting, ${feed.url} - title: ${entry.title}, published date: ${getEntryDate(entry)}`);
+	winston.verbose(`[plugin-rss] posting, ${feed.url} - title: ${entry.title}, published date: ${getEntryDate(entry)}`);
 
-	const result = await topics.post({
+	const result = await api.topics.create({ uid: posterUid, ip: '127.0.0.1' }, {
 		uid: posterUid,
 		title: entry.title,
 		content: entry.link && entry.link.href,

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -81,13 +81,10 @@ async function postEntry(feed, entry) {
 		content: entry.link && entry.link.href,
 		cid: feed.category,
 		tags: tags,
+		timestamp: feed.timestamp === 'feed' ? new Date(getEntryDate(entry)).getTime() : undefined,
 	});
 
 	const { topicData } = result;
-
-	if (feed.timestamp === 'feed') {
-		setTimestampToFeedPublishedDate(result, entry);
-	}
 
 	const max = Math.max(parseInt(meta.config.postDelay, 10) || 10, parseInt(meta.config.newbiePostDelay, 10) || 10) + 1;
 
@@ -95,26 +92,3 @@ async function postEntry(feed, entry) {
 	const uuid = entry.id || (entry.link && entry.link.href) || entry.title;
 	await db.sortedSetAdd(`nodebb-plugin-rss:feed:${feed.url}:uuid`, topicData.tid, uuid);
 }
-
-function setTimestampToFeedPublishedDate(data, entry) {
-	const { topicData } = data;
-	const { postData } = data;
-	const { tid } = topicData;
-	const { pid } = postData;
-	const timestamp = new Date(getEntryDate(entry)).getTime();
-
-	db.setObjectField(`topic:${tid}`, 'timestamp', timestamp);
-	db.sortedSetsAdd([
-		'topics:tid',
-		`cid:${topicData.cid}:tids`,
-		`cid:${topicData.cid}:uid:${topicData.uid}:tids`,
-		`uid:${topicData.uid}:topics`,
-	], timestamp, tid);
-
-	db.setObjectField(`post:${pid}`, 'timestamp', timestamp);
-	db.sortedSetsAdd([
-		'posts:pid',
-		`cid:${topicData.cid}:pids`,
-	], timestamp, pid);
-}
-

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -75,7 +75,7 @@ async function postEntry(feed, entry) {
 
 	winston.verbose(`[plugin-rss] posting, ${feed.url} - title: ${entry.title}, published date: ${getEntryDate(entry)}`);
 
-	const result = await api.topics.create({ uid: posterUid, ip: '127.0.0.1' }, {
+	const topicData = await api.topics.create({ uid: posterUid, ip: '127.0.0.1' }, {
 		uid: posterUid,
 		title: entry.title,
 		content: entry.link && entry.link.href,
@@ -83,8 +83,6 @@ async function postEntry(feed, entry) {
 		tags: tags,
 		timestamp: feed.timestamp === 'feed' ? new Date(getEntryDate(entry)).getTime() : undefined,
 	});
-
-	const { topicData } = result;
 
 	const max = Math.max(parseInt(meta.config.postDelay, 10) || 10, parseInt(meta.config.newbiePostDelay, 10) || 10) + 1;
 


### PR DESCRIPTION
The PR contains two changes:

1. Updates the `topics.post` call to call `api.topics.create` instead. This is to allow topics created via this plugin to be federated via activitypub
2. Passes `timestamp` into the call instead of changing the sorted sets after the fact