### PR TITLE
feat: save feed entry contents into topic contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const db = require.main.require('./src/database');
 const pubsub = require.main.require('./src/pubsub');
 const routeHelpers = require.main.require('./src/routes/helpers');
+const utils = require.main.require('./src/utils');
 
 const database = require('./lib/database');
 const controllers = require('./lib/controllers');
@@ -96,3 +97,17 @@ RssPlugin.widgets.defineWidgets = widget.defineWidgets;
  */
 RssPlugin.widgets.renderRssWidget = widget.render;
 
+RssPlugin.skipMarkdown = async ({ env, data }) => {
+	const feedUrls = await db.getSetMembers('nodebb-plugin-rss:feeds');
+	const keys = feedUrls.map(url => `nodebb-plugin-rss:feed:${url}:uuid`);
+	const { tid } = data.postData;
+
+	if (utils.isNumber(tid)) {
+		const entries = await db.getSortedSetRangeByScore(keys, 0, 1, tid, tid);
+		if (entries.length) {
+			env.parse = false;
+		}
+	}
+
+	return { env, data };
+};

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -21,6 +21,7 @@ Feed.getItems = async function (feedUrl, entriesToPull = Feed.DEFAULT_ENTRIES_TO
 			published: item.pubDate,
 			link: { href: item.link },
 			id: item.guid || item.id,
+			content: item.content,
 			tags: item.categories,
 		}));
 };

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -75,10 +75,14 @@ async function postEntry(feed, entry) {
 
 	winston.info(`[plugin-rss] posting, ${feed.url} - title: ${entry.title}, published date: ${getEntryDate(entry)}`);
 
+	const url = entry.link && entry.link.href;
+	const content = !entry.content.includes(url) ?
+		`${entry.content}<hr /><p><a href="${url}">${url}</a>` :
+		entry.content;
 	const result = await topics.post({
 		uid: posterUid,
 		title: entry.title,
-		content: entry.link && entry.link.href,
+		content,
 		cid: feed.category,
 		tags: tags,
 	});
@@ -92,7 +96,7 @@ async function postEntry(feed, entry) {
 	const max = Math.max(parseInt(meta.config.postDelay, 10) || 10, parseInt(meta.config.newbiePostDelay, 10) || 10) + 1;
 
 	await user.setUserField(posterUid, 'lastposttime', Date.now() - (max * 1000));
-	const uuid = entry.id || (entry.link && entry.link.href) || entry.title;
+	const uuid = entry.id || (url) || entry.title;
 	await db.sortedSetAdd(`nodebb-plugin-rss:feed:${feed.url}:uuid`, topicData.tid, uuid);
 }
 

--- a/plugin.json
+++ b/plugin.json
@@ -14,7 +14,9 @@
         { "hook": "action:topic.purge", "method": "onTopicPurge"},
 
         { "hook": "filter:widgets.getWidgets", "method": "widgets.defineWidgets" },
-        { "hook": "filter:widget.render:rss", "method": "widgets.renderRssWidget" }
+        { "hook": "filter:widget.render:rss", "method": "widgets.renderRssWidget" },
+
+        { "hook": "filter:markdown.beforeParse", "method": "skipMarkdown" }
     ],
     "templates": "./templates",
     "modules": {


### PR DESCRIPTION
This change utilises the `content` property from rss-parser to populate the topic post content. That property contains HTML, so additional logic is present here to instruct the markdown plugin to ignore it. For versions of NodeBB that don't have an up-to-date Markdown plugin, the HTML will be parsed (and likely escaped), but admins can toggle "Allow HTML" to have it rendered properly.
